### PR TITLE
feat(eslint): add rule docs for popular plugins

### DIFF
--- a/lua/rulebook/data/rule-docs.lua
+++ b/lua/rulebook/data/rule-docs.lua
@@ -12,7 +12,47 @@ local M = {
 
 	selene = "https://kampfkarren.github.io/selene/lints/%s.html",
 	yamllint = "https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.%s",
-	eslint = "https://eslint.org/docs/latest/rules/%s",
+	eslint = function(diag)
+		if not diag or not diag.code then return end
+
+		local plugin = vim.fs.dirname(diag.code)
+		local rule = vim.fs.basename(diag.code)
+
+		local pluginDocUrls = {
+			["."] = "https://eslint.org/docs/latest/rules/%s",
+			["@stencil-community"] = "https://github.com/stencil-community/stencil-eslint/blob/main/docs/%s.md",
+			["@typescript-eslint"] = "https://typescript-eslint.io/rules/%s",
+			["astro"] = "https://github.com/ota-meshi/eslint-plugin-astro/blob/main/docs/rules/%s.md",
+			["compat"] = "https://github.com/amilajack/eslint-plugin-compat/blob/main/docs/rules/%s.md",
+			["es-x"] = "https://github.com/eslint-community/eslint-plugin-es-x/blob/master/docs/rules/%s.md",
+			["eslint-plugin"] = "https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/%s.md",
+			["github"] = "https://github.com/github/eslint-plugin-github/blob/main/docs/rules/%s.md",
+			["jest"] = "https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/%s.md",
+			["jest-dom"] = "https://github.com/testing-library/eslint-plugin-jest-dom/blob/main/docs/rules/%s.md",
+			["jsdoc"] = "https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/%s.md",
+			["jsx-a11y"] = "https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/%s.md",
+			["n"] = "https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/%s.md",
+			["n/no-unsupported-features"] = "https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/no-unsupported-features/%s.md",
+			["n/prefer-global"] = "https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/prefer-global/%s.md",
+			["n/prefer-promises"] = "https://github.com/eslint-community/eslint-plugin-n/blob/master/docs/rules/prefer-promises/%s.md",
+			["promise"] = "https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/%s.md",
+			["react"] = "https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/%s.md",
+			["react-redux"] = "https://github.com/DianaSuvorova/eslint-plugin-react-redux/blob/master/docs/rules/%s.md",
+			["security"] = "https://github.com/eslint-community/eslint-plugin-security/blob/main/docs/rules/%s.md",
+			["solid"] = "https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/%s.md",
+			["svelte"] = "https://github.com/sveltejs/eslint-plugin-svelte/blob/main/docs/rules/%s.md",
+			["tailwindcss"] = "https://github.com/francoismassart/eslint-plugin-tailwindcss/blob/master/docs/rules/%s.md",
+			["testing_library"] = "https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/%s.md",
+			["unicorn"] = "https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/%s.md",
+			["vue"] = "https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/%s.md",
+			["wc"] = "https://github.com/43081j/eslint-plugin-wc/tree/master/docs/rules/%s.md",
+		}
+
+		for name, url in pairs(pluginDocUrls) do
+			if plugin == name then return string.format(url, rule) end
+		end
+	end,
+
 	stylelint = "https://stylelint.io/user-guide/rules/%s",
 	LTeX = "https://community.languagetool.org/rule/show/%s?lang=en",
 	["Lua Diagnostics."] = "https://luals.github.io/wiki/diagnostics/#%s", -- lua_ls


### PR DESCRIPTION
Add rule documentation sources for popular ESLint plugins.

## Checklist for adding rule docs / ignore comment data
- [x] Run `make update_readme` to update the list of supported sources in the README.
- [x] Use `%s` as a placeholder for the rule ID.
- [x] The source name (`diagnostic.source`) matches the name of the key in
  `rule-data.lua` (case-sensitive).

## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).
- [x] Used conventional commits keywords.
