### PR TITLE
feat: add ast-grep support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ missing.
 ### Add ignore comment
 - [alex](https://github.com/get-alex/alex#control)
 - [ansible-lint](https://ansible.readthedocs.io/projects/lint/usage/#muting-warnings-to-avoid-false-positives)
+- [ast-grep](https://ast-grep.github.io/guide/project/severity.html#ignore-linting-error)
 - [basedpyright](https://microsoft.github.io/pyright/#/comments)
 - [biome](https://biomejs.dev/linter/#ignore-code)
 - [clang-tidy](https://clang.llvm.org/extra/clang-tidy/#suppressing-undesired-diagnostics)

--- a/lua/rulebook/data/add-ignore-rule-comment.lua
+++ b/lua/rulebook/data/add-ignore-rule-comment.lua
@@ -11,6 +11,13 @@
 
 ---@type table<string, ruleIgnoreConfig>
 M = {
+	["ast-grep"] = {
+		comment = "// ast-grep-ignore: %s",
+		location = "prevLine",
+		docs = "https://ast-grep.github.io/guide/project/severity.html#ignore-linting-error",
+		multiRuleIgnore = true,
+		multiRuleSeparator = ",",
+	},
 	shellcheck = {
 		comment = "# shellcheck disable=%s",
 		location = "prevLine",

--- a/lua/rulebook/data/add-ignore-rule-comment.lua
+++ b/lua/rulebook/data/add-ignore-rule-comment.lua
@@ -12,7 +12,10 @@
 ---@type table<string, ruleIgnoreConfig>
 M = {
 	["ast-grep"] = {
-		comment = "// ast-grep-ignore: %s",
+		comment = function(diag)
+			local ignoreText = ("ast-grep-ignore: %s"):format(diag.code)
+			return vim.bo.commentstring:format(ignoreText)
+		end,
 		location = "prevLine",
 		docs = "https://ast-grep.github.io/guide/project/severity.html#ignore-linting-error",
 		multiRuleIgnore = true,


### PR DESCRIPTION
## What problem does this PR solve?

Fixes #10 

[ast-grep](https://ast-grep.github.io/) lets you easily write custom lints based on treesitter nodes with simple yaml config files. This PR adds support for adding `// ast-grep-ignore: your-rule-id` comments when using the `ast-grep` LSP.

## How does the PR solve it?

Since `ast-grep` has `ast-grep lsp` and is supported in `lspconfig`, the rule ID is provided the normal way through the diagnostic API, so this PR just adds a normal `ruleIgnoreConfig` entry.

## Checklist
- [x] Used only `camelCase` variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be
  modified).
