### PR TITLE
feat: add #[expect()] support for rust-analyzer and clippy

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Please consider making a PR to add support for a source if it is missing.
 - [basedpyright](https://microsoft.github.io/pyright/#/comments)
 - [biome](https://biomejs.dev/linter/#ignore-code)
 - [clang-tidy](https://clang.llvm.org/extra/clang-tidy/#suppressing-undesired-diagnostics)
+- [clippy / rust-analyzer](https://doc.rust-lang.org/reference/attributes/diagnostics.html#r-attributes.diagnostics.expect)
 - [codespell](https://github.com/codespell-project/codespell/issues/1212#issuecomment-1721152455)
   (requires setting `--ignore-regex` to `codespell-ignore`)
 - [cspell](https://github.com/streetsidesoftware/cspell/blob/main/packages/cspell/README.md#enable--disable-checking-sections-of-code)

--- a/lua/rulebook/data/add-ignore-rule-comment.lua
+++ b/lua/rulebook/data/add-ignore-rule-comment.lua
@@ -12,6 +12,13 @@
 ---INFO the key must be the exact case-sensitive `diagnostic.source`
 ---@type table<string, ruleIgnoreConfig>
 M = {
+	clippy = {
+		comment = "#[expect(%s)]",
+		location = "prevLine",
+		multiRuleIgnore = true,
+		multiRuleSeparator = ", ",
+		docs = "https://doc.rust-lang.org/reference/attributes/diagnostics.html#r-attributes.diagnostics.expect",
+	},
 	["ast-grep"] = {
 		comment = function(diag)
 			local ignoreText = "ast-grep-ignore: " .. diag.code
@@ -210,6 +217,7 @@ M["vale-ls"] = M.vale -- lsp and linter have separate source names
 M.stylelintplus = M.stylelint -- stylelint-lsp
 M.basedpyright = M.Pyright -- pyright fork
 M.ltex_plus = M.LTeX -- ltex fork
+M["rust-analyzer"] = M.clippy -- they use the same Rust attribute syntax
 
 --------------------------------------------------------------------------------
 return M


### PR DESCRIPTION
## What problem does this PR solve?

Add `#[expect()]` attribute support to ignore clippy/rust-analyzer support.

The attribute text can be customized via user config, which can be useful if users need to use `#[allow()]` instead, or like in some more complicated projects, sometimes you need to do `#[cfg_attr(not(target = "wasm32"), expect(clippy::large_enum_variant))]` because this lint does not trigger in WASM builds. A user could do this by using a Lua function in the plugin config.

## How does the PR solve it?

## Checklist
- [x] Used only `camelCase` variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be
  modified).
